### PR TITLE
Require new zope.app.locales version to fix extract on Python 3.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ CHANGES
 1.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix extraction on Python 3 by requiring a more recent version of
+  `zope.app.locales`.
 
 
 1.1 (2019-01-27)

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         "setuptools",
         "zc.buildout >= 2.0.0",
         "zc.recipe.egg",
-        "zope.app.locales[extract] >= 4.0",
+        "zope.app.locales[extract] >= 4.1",
     ],
     entry_points={"zc.buildout": ["i18n = z3c.recipe.i18n.i18n:I18nSetup"]},
     test_suite="z3c.recipe.i18n",

--- a/src/z3c/recipe/i18n/i18nextract.py
+++ b/src/z3c/recipe/i18n/i18nextract.py
@@ -65,52 +65,12 @@ Options:
 import getopt
 import os
 import sys
-import time
 
-from zope.app.locales.extract import DEFAULT_CHARSET
-from zope.app.locales.extract import DEFAULT_ENCODING
-from zope.app.locales.extract import pot_header as _DEFAULT_POT_HEADER
 from zope.app.locales.extract import POTMaker
 from zope.app.locales.extract import py_strings
 from zope.app.locales.extract import tal_strings
 from zope.app.locales.extract import zcml_strings
 from zope.configuration.name import resolve
-
-
-class POTMaker(POTMaker):
-    """This class inserts sets of strings into a POT file.
-    """
-
-    def __init__(self, output_fn, path, header_template=None):
-        self._output_filename = output_fn
-        self.path = path
-        if header_template is not None and os.path.exists(header_template):
-            with open(header_template, "r") as file:
-                self._pot_header = file.read()
-        else:
-            self._pot_header = _DEFAULT_POT_HEADER
-        self.catalog = {}
-
-    def write(self):
-        pot_header = self._pot_header
-
-        with open(self._output_filename, "w") as file:
-            file.write(
-                pot_header
-                % {
-                    "time": time.ctime(),
-                    "version": self._getProductVersion(),
-                    "charset": DEFAULT_CHARSET,
-                    "encoding": DEFAULT_ENCODING,
-                }
-            )
-
-            # Sort the catalog entries by filename
-            catalog = sorted(self.catalog.values())
-
-            # Write each entry to the file
-            for entry in catalog:
-                entry.write(file)
 
 
 def usage(code, msg=""):


### PR DESCRIPTION
This PR is broken until `zope.app.locales` 4.1 is released.

See zopefoundation/zope.app.locales#11.